### PR TITLE
Update Device Tree for Edge Comm Card

### DIFF
--- a/src/arm/BB-ZOLA-GATEWAY-00A0.dts
+++ b/src/arm/BB-ZOLA-GATEWAY-00A0.dts
@@ -300,3 +300,20 @@
 	status = "disabled";
 };
 
+/* PWM outputs for Zola Power On LED (J16-Pins 4, 6,8) */
+&ocp {
+	/* See BeagleBone_Black.dts */
+	P9_29_pinmux { status = "disabled"; }; /* gpio3_15, 0x0994 */
+	P9_30_pinmux { status = "disabled"; }; /* gpio3_16, 0x0998 */
+	P9_28_pinmux { status = "disabled"; }; /* gpio3_17, 0x099c */
+};
+
+&am33x_pinmux {
+	led_pins: led_pins {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x0994, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
+			AM33XX_IOPAD(0x0998, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
+			AM33XX_IOPAD(0x099c, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
+		>;
+	};
+};

--- a/src/arm/BB-ZOLA-GATEWAY-00A0.dts
+++ b/src/arm/BB-ZOLA-GATEWAY-00A0.dts
@@ -302,7 +302,6 @@
 
 /* PWM outputs for Zola Power On LED (J16-Pins 4, 6,8) */
 &ocp {
-	/* See BeagleBone_Black.dts */
 	P9_29_pinmux { status = "disabled"; }; /* gpio3_15, 0x0994 */
 	P9_30_pinmux { status = "disabled"; }; /* gpio3_16, 0x0998 */
 	P9_28_pinmux { status = "disabled"; }; /* gpio3_17, 0x099c */
@@ -314,6 +313,19 @@
 			AM33XX_IOPAD(0x0994, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
 			AM33XX_IOPAD(0x0998, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
 			AM33XX_IOPAD(0x099c, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE1)
+		>;
+	};
+};
+
+/* Digital Output (J6 Pins 4, 11, 14) */
+&ocp {
+	P8_19_pinmux { status = "disabled"; }; /* gpio0_22, 0x0820 */
+};
+
+&am33x_pinmux {
+	relay_control_pin: relay_control_pin {
+		pinctrl-single,pins = <
+			AM33XX_IOPAD(0x0820, PIN_OUTPUT | MUX_MODE7)
 		>;
 	};
 };


### PR DESCRIPTION
- (New) 3x Pins for the PWM Outputs to the Zola Power On LED (J16-Pins 4, 6, 8) - These are GPIO 3_15, 3_16, and 3_17. These now need to be setup for PWM.
- Update/Ensure 1x Digital Inputs Exists for Automatic Generator Control Sense (J6 Pins 8 ) - AM335X_DI_1.
- Update/Ensure 1x Digital Inputs Exists for Generator On Sense (J6 Pins 6) - AM335X_DI_2.
- Update/Ensure Exist Relay Control - 1x Digital Outputs (J6 Pins 4, 11, 14) Map to GPIO 0_22
